### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "farmhash"
+description := "A family of hash functions."
+gitrepo     := "https://github.com/google/farmhash.git"
+homepage    := "https://github.com/google/farmhash/"
+version     := 816a4ae sha256:6560547c63e4af82b0f202cb710ceabb3f21347a4b996db565a411da5b17aba0 https://github.com/google/farmhash/archive/816a4ae.tar.gz
+license     := "MIT"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

